### PR TITLE
Fix bug with John references not working past chapter 1

### DIFF
--- a/action-readPassage.py
+++ b/action-readPassage.py
@@ -53,7 +53,7 @@ def readPassage(reference):
 
 def readPassage_callback(hermes, intentMessage):
 	book = intentMessage.slots.book[0].slot_value.value.value
-	if book in ('Jude, 3 John, Philemon'):
+	if book in ('Jude', '3 John', 'Philemon'):
 		verse = intentMessage.slots.chapter[0].slot_value.value.value
 		chapter = 1.0
 		second_chapter = 1.0


### PR DESCRIPTION
There was a simple bug with John references not working past chapter 1 because of this bit of code:
```python
	if book in ('Jude, 3 John, Philemon'):
```
This bit of code would trigger with John references as well since `('Jude, 3 John, Philemon')` is a single string instead of a tuple of 3 strings so comparing it with "John" would do a substring check and match because of '3 John'.